### PR TITLE
pytorch deprecation - torch.symeig -> torch.linalg.eigh

### DIFF
--- a/simple_sfm/utils/geometry.py
+++ b/simple_sfm/utils/geometry.py
@@ -354,7 +354,7 @@ def average_quaternions(quaternions: torch.Tensor,
     # B x 4 X 4
     mat_a = torch.einsum('bni,bnj->bij', [quaternions * weights, quaternions])
     # compute eigenvalues and -vectors
-    _, eigen_vectors = torch.symeig(mat_a, eigenvectors=True)
+    _, eigen_vectors = torch.linalg.eigh(mat_a)
     max_value_eigenvector = eigen_vectors[..., -1].reshape(*batch_shape, 4)
 
     return max_value_eigenvector.unsqueeze(-2) if keepdim else max_value_eigenvector


### PR DESCRIPTION
fix "This function was deprecated since version 1.9 and is now removed. Please use the torch.linalg.eigh function instead."

Associated issue :  https://github.com/palsol/SimpleSfm/issues/1
https://github.com/SamsungLabs/MLI/issues/14

Changes only done in colab branch